### PR TITLE
Map: is_empty(), len(), iter()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,5 @@ mod map;
 pub use object::Managed;
 pub use slice::ManagedSlice;
 #[cfg(feature = "map")]
-pub use map::ManagedMap;
+pub use map::{ManagedMap,
+              Iter as ManagedMapIter};

--- a/src/map.rs
+++ b/src/map.rs
@@ -224,9 +224,14 @@ impl<'a, K: Ord + 'a, V: 'a> ManagedMap<'a, K, V> {
         }
     }
 
-    /// Short-cut for `into_iter()`
     pub fn iter(&'a self) -> Iter<'a, K, V> {
-        self.into_iter()
+        match self {
+            &ManagedMap::Borrowed(ref pairs) =>
+                Iter::Borrowed(pairs.iter()),
+            #[cfg(any(feature = "std", feature = "alloc"))]
+            &ManagedMap::Owned(ref map) =>
+                Iter::Owned(map.iter()),
+        }
     }
 }
 
@@ -235,13 +240,7 @@ impl<'a, K: Ord + 'a, V: 'a> IntoIterator for &'a ManagedMap<'a, K, V> {
     type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self {
-            &ManagedMap::Borrowed(ref pairs) =>
-                Iter::Borrowed(pairs.iter()),
-            #[cfg(any(feature = "std", feature = "alloc"))]
-            &ManagedMap::Owned(ref map) =>
-                Iter::Owned(map.iter()),
-        }
+        self.iter()
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -235,15 +235,6 @@ impl<'a, K: Ord + 'a, V: 'a> ManagedMap<'a, K, V> {
     }
 }
 
-impl<'a, K: Ord + 'a, V: 'a> IntoIterator for &'a ManagedMap<'a, K, V> {
-    type Item = (&'a K, &'a V);
-    type IntoIter = Iter<'a, K, V>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
 pub enum Iter<'a, K: 'a, V: 'a> {
     /// Borrowed variant.
     Borrowed(slice::Iter<'a, Option<(K, V)>>),


### PR DESCRIPTION
Thank you for this gem of a crate! I'm going to need this in my work on smoltcp's `igmp` branch, so I'd certainly appreciate an early release if the patchset is fine.

This one is implementing half of #4. For `iter_mut()` you could take a look at my branch [map-iter_mut](https://github.com/astro/rust-managed/blob/map-iter_mut/src/map.rs) which has just one remaining type-checking problem. :-(