### PR TITLE
Do not constrain to 'static lifetime

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -25,7 +25,7 @@ use alloc::vec::Vec;
 /// argument; then, it will be possible to pass either a `Box<T>`, `Vec<T>`, or a `&'a mut T`
 /// without any conversion at the call site.
 ///
-/// Note that a `Vec<T>` converted into an `Into<Managed<'static, [T]>>` gets transformed
+/// Note that a `Vec<T>` converted into an `Into<Managed<'a, [T]>>` gets transformed
 /// into a boxed slice, and can no longer be resized. See also
 /// [ManagedSlice](enum.ManagedSlice.html), which does not have this drawback.
 pub enum Managed<'a, T: 'a + ?Sized> {
@@ -54,14 +54,14 @@ impl<'a, T: 'a + ?Sized> From<&'a mut T> for Managed<'a, T> {
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: ?Sized + 'static> From<Box<T>> for Managed<'static, T> {
+impl<'a, T: ?Sized + 'a> From<Box<T>> for Managed<'a, T> {
     fn from(value: Box<T>) -> Self {
         Managed::Owned(value)
     }
 }
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: 'static> From<Vec<T>> for Managed<'static, [T]> {
+impl<'a, T: 'a> From<Vec<T>> for Managed<'a, [T]> {
     fn from(value: Vec<T>) -> Self {
         Managed::Owned(value.into_boxed_slice())
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -71,7 +71,7 @@ from_unboxed_slice!(0,  1,   2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 
                     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-impl<T: 'static> From<Vec<T>> for ManagedSlice<'static, T> {
+impl<'a, T: 'a> From<Vec<T>> for ManagedSlice<'a, T> {
     fn from(value: Vec<T>) -> Self {
         ManagedSlice::Owned(value)
     }


### PR DESCRIPTION
Let the compiler infer the appropriate 'a lifetime.

Tested with smoltcp build/test.